### PR TITLE
Fix broken mailto link on contact page

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -4,6 +4,6 @@ title: "Contact"
 
 If you have any questions, suggestions or anything else feel free to contact me:
 
-* Mail: [mxstrbng@gmail.com](mailto:mxstrbng@gmail)
+* Mail: [mxstrbng@gmail.com](mailto:mxstrbng@gmail.com)
 * Twitter: [mxstrbng](https://twitter.com/mxstrbng)
 * Neos-Slack: [mstruebing](https://neos-project.slack.com/messages/D1N1C56EQ/)


### PR DESCRIPTION
`@gmail` is not yet an actual google-owned domain 😅